### PR TITLE
Fixes to schedules and DDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - `max_steps` is automatically inferred from the tuning config if a number of lr decay steps is
   given
-- `max_epochs` is not optional (if both `max_steps` and `max_epochs` are unset, Lightning's default will be used)
+- `max_epochs` is not optional (if both `max_steps` and `max_epochs` are unset and no lr schedule is
+  provided, Lightning's default will be used)
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   given
 - `max_epochs` is not optional (if both `max_steps` and `max_epochs` are unset and no lr schedule is
   provided, Lightning's default will be used)
+- `find_unused_parameters` is now disabled in DDP mode, unless in profile mode
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 [Unreleased]: https://github.com/LoicGrobol/zeldarose/compare/v0.3.2...HEAD
 
+## Changed
+
+- `max_steps` is automatically inferred from the tuning config if a number of lr decay steps is
+  given
+- `max_epochs` is not optional (if both `max_steps` and `max_epochs` are unset, Lightning's default will be used)
+
+## Fixed
+
+- Linear decay now properly takes the warmup period into account
+
 ## [0.3.2] — 2021-05-3&
 
 [0.3.2]: https://github.com/LoicGrobol/zeldarose/compare/v0.3.1...v0.3.2

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,9 @@ skip_missing_interpreters = true
 allowlist_externals=cmp
 commands =
     zeldarose-tokenizer --vocab-size 4096 --out-path {envtmpdir}/tokenizer  --model-name "my-muppet" tests/fixtures/raw.txt
-    zeldarose-transformer --tokenizer {envtmpdir}/tokenizer/my-muppet --pretrained-model flaubert/flaubert_small_cased --device-batch-size 8 --out-dir {envtmpdir}/custom-tok --cache-dir {envtmpdir}/tokenizer-cache --val-text tests/fixtures/raw.txt tests/fixtures/raw.txt
-    zeldarose-transformer --tokenizer flaubert/flaubert_small_cased --pretrained-model flaubert/flaubert_small_cased --device-batch-size 8 --out-dir {envtmpdir}/pretrained-tok --cache-dir {envtmpdir}/tokenizer-cache --val-text tests/fixtures/raw.txt tests/fixtures/raw.txt
-    zeldarose-transformer --checkpoint {envtmpdir}/pretrained-tok/lightning_logs/version_0/checkpoints/epoch=1-step=3.ckpt --max-epochs 4 --tokenizer flaubert/flaubert_small_cased --pretrained-model flaubert/flaubert_small_cased --device-batch-size 8 --out-dir {envtmpdir}/pretrained-tok --cache-dir {envtmpdir}/tokenizer-cache --val-text tests/fixtures/raw.txt tests/fixtures/raw.txt
+    zeldarose-transformer --tokenizer {envtmpdir}/tokenizer/my-muppet --pretrained-model flaubert/flaubert_small_cased --device-batch-size 8 --out-dir {envtmpdir}/custom-tok --cache-dir {envtmpdir}/tokenizer-cache --val-text tests/fixtures/raw.txt tests/fixtures/raw.txt --max-epochs 2
+    zeldarose-transformer --tokenizer flaubert/flaubert_small_cased --pretrained-model flaubert/flaubert_small_cased --device-batch-size 8 --out-dir {envtmpdir}/pretrained-tok --cache-dir {envtmpdir}/tokenizer-cache --val-text tests/fixtures/raw.txt tests/fixtures/raw.txt --max-epochs 2
+    zeldarose-transformer --checkpoint {envtmpdir}/pretrained-tok/lightning_logs/version_0/checkpoints/epoch=1-step=3.ckpt --max-epochs 4 --tokenizer flaubert/flaubert_small_cased --pretrained-model flaubert/flaubert_small_cased --device-batch-size 8 --out-dir {envtmpdir}/pretrained-tok --cache-dir {envtmpdir}/tokenizer-cache --val-text tests/fixtures/raw.txt tests/fixtures/raw.txt --max-epochs 2
 
 [py39]
 ignore_outcome = true

--- a/zeldarose/data.py
+++ b/zeldarose/data.py
@@ -47,6 +47,7 @@ def encode_dataset(
         new_fingerprint=f"{raw_dataset._fingerprint}-{tokenizer_name}-{max_length}",
     )
     logger.info(f"Saving dataset to {save_path}")
+    # FIXME: this causes an obscure crash whe, two instance want to access the same --cache-dir
     encoded_dataset.save_to_disk(save_path)
 
 

--- a/zeldarose/data.py
+++ b/zeldarose/data.py
@@ -1,7 +1,7 @@
 import os
 import pathlib
 
-from typing import List, NamedTuple, Optional, Sequence, TypedDict
+from typing import cast, List, NamedTuple, Optional, Sequence, TypedDict
 
 import datasets
 import pytorch_lightning as pl
@@ -23,19 +23,27 @@ def encode_dataset(
     max_length: Optional[int] = None,
 ):
     logger.info(f"Loading data from {text_path}")
-    raw_dataset = datasets.load_dataset(
-        "text", data_files=str(text_path), split="train"
-    ).filter(lambda example: len(example["text"]) > 0 and not example["text"].isspace())
+    raw_dataset = cast(
+        datasets.Dataset,
+        datasets.load_dataset("text", data_files=str(text_path), split="train"),
+    ).filter(
+        (lambda example: len(example) > 0 and not example.isspace()),
+        input_columns="text",
+    )
     logger.info("Tokenizing")
     encoded_dataset = raw_dataset.map(
-        lambda examples: tokenizer(
-            examples["text"],
-            add_special_tokens=True,
-            max_length=max_length,
-            return_special_tokens_mask=True,
-            truncation=True,
+        (
+            lambda examples: tokenizer(
+                examples,
+                add_special_tokens=True,
+                max_length=max_length,
+                return_special_tokens_mask=True,
+                truncation=True,
+            )
         ),
         batched=True,
+        desc="Tokenizing",
+        input_columns="text",
         new_fingerprint=f"{raw_dataset._fingerprint}-{tokenizer_name}-{max_length}",
     )
     logger.info(f"Saving dataset to {save_path}")

--- a/zeldarose/mlm.py
+++ b/zeldarose/mlm.py
@@ -180,28 +180,29 @@ class MLMFinetuner(pl.LightningModule):
 
         loss = outputs.loss
 
-        preds = torch.argmax(outputs.logits, dim=-1)
-        perplexity = torch.exp(loss)
-        self.accuracy(preds, masked.labels)
+        with torch.no_grad():
+            preds = torch.argmax(outputs.logits, dim=-1)
+            perplexity = torch.exp(loss)
+            self.accuracy(preds, masked.labels)
 
-        self.log(
-            "train/loss",
-            loss,
-            reduce_fx=torch.mean,
-            on_epoch=True,
-            sync_dist=True,
-        )
-        self.log(
-            "train/perplexity",
-            perplexity,
-            on_epoch=True,
-            sync_dist=True,
-        )
-        self.log(
-            "train/accuracy",
-            self.accuracy,
-            on_epoch=True,
-        )
+            self.log(
+                "train/loss",
+                loss,
+                reduce_fx=torch.mean,
+                on_epoch=True,
+                sync_dist=True,
+            )
+            self.log(
+                "train/perplexity",
+                perplexity,
+                on_epoch=True,
+                sync_dist=True,
+            )
+            self.log(
+                "train/accuracy",
+                self.accuracy,
+                on_epoch=True,
+            )
         return loss
 
     def validation_step(self, batch: zeldarose.data.TextBatch, batch_idx: int):

--- a/zeldarose/mlm.py
+++ b/zeldarose/mlm.py
@@ -283,14 +283,17 @@ class MLMFinetuner(pl.LightningModule):
         )
         if self.config.lr_decay_steps:
             if self.config.lr_decay_steps == -1:
-                num_training_steps = self.trainer.max_steps
+                num_training_steps = self.trainer.max_steps - self.config.warmup_steps
+                logger.info(
+                    f"Number of lr decay steps set at {num_training_steps} since -1 was asked"
+                )
             else:
                 num_training_steps = self.config.lr_decay_steps
 
             schedule = transformers.get_linear_schedule_with_warmup(
                 optimizer,
                 num_warmup_steps=self.config.warmup_steps,
-                num_training_steps=num_training_steps,
+                num_training_steps=num_training_steps + self.config.warmup_steps,
             )
             schedulers = [{"scheduler": schedule, "interval": "step"}]
         elif self.config.warmup_steps > 0:

--- a/zeldarose/train_transformer.py
+++ b/zeldarose/train_transformer.py
@@ -449,7 +449,7 @@ def main(
 
     if accelerator is not None and "ddp" in accelerator:
         cast(List, additional_kwargs.setdefault("plugins", [])).append(
-            DDPPlugin(find_unused_parameters=False, num_nodes=n_nodes),
+            DDPPlugin(find_unused_parameters=not profile, num_nodes=n_nodes),
         )
 
     if accelerator == "ddp_cpu":

--- a/zeldarose/train_transformer.py
+++ b/zeldarose/train_transformer.py
@@ -18,6 +18,7 @@ import torch.cuda
 import transformers
 
 from loguru import logger
+from pytorch_lightning.plugins import DDPPlugin
 from pytorch_lightning.utilities import rank_zero_only
 
 from zeldarose import data
@@ -445,7 +446,11 @@ def main(
         logger.info("Automatic batch size selection")
         additional_kwargs.update({"auto_scale_batch_size": "binsearch"})
 
-    # TODO: find a way to set find_unused_parameters=False
+    if accelerator is not None and "ddp" in accelerator:
+        cast(List, additional_kwargs.setdefault("plugins", [])).append(
+            DDPPlugin(find_unused_parameters=False),
+        )
+
     if accelerator == "ddp_cpu":
         # FIXME: works but seems like bad practice
         additional_kwargs["num_processes"] = n_gpus

--- a/zeldarose/train_transformer.py
+++ b/zeldarose/train_transformer.py
@@ -206,7 +206,6 @@ class SavePretrainedModelCallback(pl.callbacks.Callback):
 @click.option(
     "--max-epochs",
     type=click.IntRange(0),
-    default=2,
     help="How many epochs to train for",
 )
 @click.option(
@@ -302,7 +301,7 @@ def main(
     config_path: Optional[pathlib.Path],
     device_batch_size: Optional[int],
     guess_batch_size: bool,
-    max_epochs: int,
+    max_epochs: Optional[int],
     max_steps: Optional[int],
     model_config_path: Optional[str],
     model_name: str,
@@ -496,6 +495,12 @@ def main(
 
     if checkpoint is not None:
         additional_kwargs["resume_from_checkpoint"] = checkpoint
+
+    if max_steps is None and tuning_config.lr_decay_steps is not None:
+        max_steps = tuning_config.lr_decay_steps + tuning_config.warmup_steps
+        logger.info(
+            f"Setting the max number of steps at {max_steps} according to the tuning config"
+        )
 
     trainer = pl.Trainer(
         accumulate_grad_batches=accumulate_grad_batches,

--- a/zeldarose/train_transformer.py
+++ b/zeldarose/train_transformer.py
@@ -421,6 +421,7 @@ def main(
         getattr(model.config, "max_position_embeddings", float("inf"))
         - tokenizer.num_special_tokens_to_add(pair=False),
     )
+    logger.info(f"Training with a maximum sequence length of {max_length} tokens")
     logger.info("Creating data modules")
     datamodule = data.TextDataModule(
         data_dir=cache_dir,

--- a/zeldarose/train_transformer.py
+++ b/zeldarose/train_transformer.py
@@ -448,7 +448,7 @@ def main(
 
     if accelerator is not None and "ddp" in accelerator:
         cast(List, additional_kwargs.setdefault("plugins", [])).append(
-            DDPPlugin(find_unused_parameters=False),
+            DDPPlugin(find_unused_parameters=False, num_nodes=n_nodes),
         )
 
     if accelerator == "ddp_cpu":


### PR DESCRIPTION
## Changed

- `max_steps` is automatically inferred from the tuning config if a number of lr decay steps is
  given
- `max_epochs` is not optional (if both `max_steps` and `max_epochs` are unset and no lr schedule is
  provided, Lightning's default will be used)
- `find_unused_parameters` is now disabled in DDP mode, unless in profile mode

## Fixed

- Linear decay now properly takes the warmup period into account