### PR TITLE
Update to reflect the interfaces in lightning 1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Changed
 
+- The command line options have been changed to reflect change in Lightning
+  - `--accelerator` is now used for devices, tested values are `"cpu"` and `"gpu"`
+  - `--strategy` now specifies how to train, tested values are `None` (missing), `"ddp"`,
+    `"ddp_sharded"` `"ddp_spawn"` and`"ddp_sharded_spawn"`.
+  - No more option to select sharded training, use the strategy alias for that
+  - `--n-gpus` has been renamed to `--num-devices`.
 - Training task configs now have a `type` config key to specify the task type
 - Lightning progress bars are now provided by [Rich](https://rich.readthedocs.io)
 
@@ -25,6 +31,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - Tests now run in [Pytest](https://pytest.org) using the [console-scripts
   plugin](https://github.com/kvas-it/pytest-console-scripts) for smoke tests.
+- Smoke tests now include `ddp_spawn` tests and tests on gpu devices if available.
 - Some refactoring for better factorization of the common utilities for MLM and RTD.
 
 ## [0.3.4] — 2021-12-21

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ This is somewhat tricky, you have several options
 - If you are running in a SLURM cluster use `--accelerator ddp` and invoke via `srun`
 - Otherwise you have two options
 
-  - Run with `--accelerator ddp_spawn`, which uses `multiprocessing.spawn` to start the process
+  - Run with `--strategy ddp_spawn`, which uses `multiprocessing.spawn` to start the process
     swarm (tested, but possibly slower and more limited, see `pytorch-lightning` doc)
-  - Run with `--accelerator ddp` and start with `torch.distributed.launch` with `--use_env` and
+  - Run with `--strategy ddp` and start with `torch.distributed.launch` with `--use_env` and
     `--no_python` (untested)
 
 ## Other hints

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,10 @@ def mlm_task_config(test_data_dir: pathlib.Path) -> pathlib.Path:
 
 @pytest.fixture(
     params=[
-        "lgrobol/electra-minuscule-discriminator,lgrobol/electra-minuscule-generator"
+        pytest.param(
+            "lgrobol/electra-minuscule-discriminator,lgrobol/electra-minuscule-generator",
+            id="lgrobol/electra-minuscule",
+        )
     ],
     scope="session",
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ def raw_text_path(test_data_dir: pathlib.Path) -> pathlib.Path:
     params=[
         "lgrobol/flaubert-minuscule",
         "lgrobol/roberta-minuscule",
-        fixtures_dir / "roberta-minuscule",
+        pytest.param(fixtures_dir / "roberta-minuscule", id="roberta-minuscule-local"),
     ],
     scope="session",
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,7 @@ def mlm_model_config(request) -> str:
 
 
 @pytest.fixture(scope="session")
-def mlm_task_config(test_data_dir: pathlib.Path) -> str:
+def mlm_task_config(test_data_dir: pathlib.Path) -> pathlib.Path:
     return test_data_dir / "mlm-config.toml"
 
 
@@ -56,5 +56,5 @@ def rtd_model_config(request) -> str:
 
 
 @pytest.fixture(scope="session")
-def rtd_task_config(test_data_dir: pathlib.Path) -> str:
+def rtd_task_config(test_data_dir: pathlib.Path) -> pathlib.Path:
     return test_data_dir / "rtd-config.toml"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ def tokenizer_name_or_path(request) -> str:
     params=[
         "lgrobol/flaubert-minuscule",
         "lgrobol/roberta-minuscule",
-        fixtures_dir / "roberta-minuscule",
+        pytest.param(fixtures_dir / "roberta-minuscule", id="roberta-minuscule-local"),
     ],
     scope="session",
 )
@@ -46,7 +46,9 @@ def mlm_task_config(test_data_dir: pathlib.Path) -> str:
 
 
 @pytest.fixture(
-    params=["lgrobol/electra-minuscule-discriminator,lgrobol/electra-minuscule-generator"],
+    params=[
+        "lgrobol/electra-minuscule-discriminator,lgrobol/electra-minuscule-generator"
+    ],
     scope="session",
 )
 def rtd_model_config(request) -> str:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,6 +1,7 @@
 import pathlib
 from typing import List, Optional, Tuple, Union
 
+from pytorch_lightning.utilities import _FAIRSCALE_AVAILABLE
 import torch.cuda
 
 import pytest
@@ -14,9 +15,9 @@ accelerators_strategies_devices = [
 if torch.cuda.is_available():
     accelerators_strategies_devices.append(("gpu", None, None))
     if torch.cuda.device_count() > 1:
-        accelerators_strategies_devices.extend(
-            [("gpu", "ddp_spawn", 2), ("gpu", "ddp_sharded_spawn", 2)]
-        )
+        accelerators_strategies_devices.append(("gpu", "ddp_spawn", 2))
+        if _FAIRSCALE_AVAILABLE:
+            accelerators_strategies_devices.append(("gpu", "ddp_sharded_spawn", 2))
 
 
 def test_train_tokenizer(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -58,7 +58,7 @@ def test_train_mlm(
     if strategy is not None:
         extra_args.extend(["--strategy", strategy])
     if devices is not None:
-        extra_args.extend(["--devices", str(devices)])
+        extra_args.extend(["--num-devices", str(devices)])
 
     ret = script_runner.run(
         "zeldarose-transformer",
@@ -81,11 +81,20 @@ def test_train_mlm(
         str(raw_text_path),
         "--max-epochs",
         "2",
+        *extra_args,
     )
     assert ret.success
 
 
+@pytest.mark.parametrize(
+    "accelerators_strategies_devices",
+    [
+        pytest.param(v, id="+".join(map(str, v)))
+        for v in accelerators_strategies_devices
+    ],
+)
 def test_train_rtd(
+    accelerators_strategies_devices: Tuple[str, Optional[str], Optional[int]],
     rtd_model_config: Union[pathlib.Path, str],
     rtd_task_config: pathlib.Path,
     raw_text_path: pathlib.Path,
@@ -93,8 +102,17 @@ def test_train_rtd(
     tmp_path: pathlib.Path,
     tokenizer_name_or_path: Union[pathlib.Path, str],
 ):
+    accelerator, strategy, num_devices = accelerators_strategies_devices
+
+    extra_args: List[str] = []
+    if strategy is not None:
+        extra_args.extend(["--strategy", strategy])
+    if num_devices is not None:
+        extra_args.extend(["--num-devices", str(num_devices)])
     ret = script_runner.run(
         "zeldarose-transformer",
+        "--accelerator",
+        accelerator,
         "--config",
         str(rtd_task_config),
         "--tokenizer",
@@ -112,5 +130,6 @@ def test_train_rtd(
         str(raw_text_path),
         "--max-epochs",
         "2",
+        *extra_args,
     )
     assert ret.success

--- a/zeldarose/mlm.py
+++ b/zeldarose/mlm.py
@@ -6,7 +6,6 @@ import pytorch_lightning as pl
 import torch
 import torch.jit
 import torch.utils.data
-import torchmetrics
 import transformers
 
 from loguru import logger
@@ -114,6 +113,7 @@ class MLMTrainingModel(pl.LightningModule):
 
         self.save_hyperparameters("training_config", "task_config")
 
+    # type: ignore[override]
     def forward(
         self,
         tokens: torch.Tensor,
@@ -131,6 +131,7 @@ class MLMTrainingModel(pl.LightningModule):
 
         return output
 
+    # type: ignore[override]
     def training_step(
         self, batch: zeldarose.data.TextBatch, batch_idx: int
     ) -> torch.Tensor:
@@ -180,6 +181,7 @@ class MLMTrainingModel(pl.LightningModule):
             )
         return loss
 
+    # type: ignore[override]
     def validation_step(self, batch: zeldarose.data.TextBatch, batch_idx: int):
         tokens, attention_mask, internal_tokens_mask, token_type_ids = batch
         with torch.no_grad():

--- a/zeldarose/train_transformer.py
+++ b/zeldarose/train_transformer.py
@@ -400,11 +400,6 @@ def main(
         logger.info("Automatic batch size selection")
         additional_kwargs.update({"auto_scale_batch_size": "binsearch"})
 
-    if strategy is not None and "ddp" in strategy:
-        cast(List, additional_kwargs.setdefault("plugins", [])).append(
-            DDPPlugin(find_unused_parameters=profile),
-        )
-
     if accelerator == "gpu":
         if use_fp16:
             logger.info(f"Training the model on {num_devices} GPUs with half precision")

--- a/zeldarose/train_transformer.py
+++ b/zeldarose/train_transformer.py
@@ -6,7 +6,7 @@ import pathlib
 import sys
 import warnings
 
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional, Union
 
 import click
 import click_pathlib
@@ -15,7 +15,6 @@ import toml
 import transformers
 
 from loguru import logger
-from pytorch_lightning.plugins import DDPPlugin
 from pytorch_lightning.utilities import rank_zero_only
 from zeldarose import data, rtd
 from zeldarose import mlm
@@ -322,6 +321,7 @@ def main(
     tuning_config = TrainConfig.parse_obj(config.get("tuning", dict()))
 
     task_type = config.get("type", "mlm")
+    training_model: Union[mlm.MLMTrainingModel, rtd.RTDTrainingModel]
     if task_type == "mlm":
         training_model = mlm.get_training_model(
             model_config_path=model_config_path,

--- a/zeldarose/train_transformer.py
+++ b/zeldarose/train_transformer.py
@@ -135,6 +135,7 @@ class SavePretrainedModelCallback(pl.callbacks.Callback):
 )
 @click.option(
     "--accelerator",
+    default="cpu",
     type=str,
     help="The lightning accelerator to use (see lightning doc)",
 )
@@ -198,10 +199,10 @@ class SavePretrainedModelCallback(pl.callbacks.Callback):
     help="A name to give to the model",
 )
 @click.option(
-    "--n-gpus",
-    default=0,
-    type=click.IntRange(0),
-    help="How many GPUs to train on. In ddp_cpu mode, this is the number of processes",
+    "--num-devices",
+    default=1,
+    type=click.IntRange(1),
+    help="How many devices to train on. If `accelerator` is `cpu`, this is the number of processes",
 )
 @click.option(
     "--n-nodes",
@@ -234,9 +235,9 @@ class SavePretrainedModelCallback(pl.callbacks.Callback):
     default=0,
 )
 @click.option(
-    "--sharded-ddp",
-    is_flag=True,
-    help="Activate to use the sharded DDP mode (requires fairscale)",
+    "--strategy",
+    type=str,
+    help="The lightning strategy to use (see lightning doc)",
 )
 @click.option("--profile", is_flag=True, help="Run in profiling mode")
 @click.option(
@@ -253,7 +254,7 @@ class SavePretrainedModelCallback(pl.callbacks.Callback):
 @click.option(
     "--use-fp16",
     is_flag=True,
-    help="Activate half-preicions mode (only on GPUs)",
+    help="Activate half-precisions mode (only on GPUs)",
 )
 @click.option(
     "--val-text",
@@ -263,7 +264,7 @@ class SavePretrainedModelCallback(pl.callbacks.Callback):
 )
 @click.option("--verbose", is_flag=True, help="More detailed logs")
 def main(
-    accelerator: Optional[str],
+    accelerator: str,
     cache_dir: Optional[pathlib.Path],
     checkpoint: Optional[pathlib.Path],
     config_path: Optional[pathlib.Path],
@@ -273,15 +274,15 @@ def main(
     max_steps: Optional[int],
     model_config_path: Optional[str],
     model_name: str,
-    n_gpus: int,
     n_nodes: int,
     n_workers: int,
+    num_devices: int,
     out_dir: pathlib.Path,
     pretrained_model: Optional[str],
     profile: bool,
     raw_text: pathlib.Path,
     save_period: int,
-    sharded_ddp: bool,
+    strategy: Optional[str],
     tokenizer_name: Optional[str],
     use_fp16: bool,
     val_path: Optional[pathlib.Path],
@@ -298,12 +299,10 @@ def main(
     # out something like `optim_batch_size` that takes into account the number of tasks and the
     # number of samples per gpu
     if (num_slurm_tasks := os.environ.get("SLURM_NTASKS")) is not None:
-        n_devices = int(num_slurm_tasks)
-    elif n_gpus:
-        n_devices = n_nodes * n_gpus
+        total_devices = int(num_slurm_tasks)
     else:
-        n_devices = 1
-    logger.info(f"Training on {n_devices} devices.")
+        total_devices = n_nodes * num_devices
+    logger.info(f"Training on a total of {total_devices} devices.")
 
     if tokenizer_name is None:
         if pretrained_model is not None:
@@ -345,29 +344,29 @@ def main(
 
     if device_batch_size is None:
         device_batch_size = tuning_config.batch_size
-    elif tuning_config.batch_size < device_batch_size * n_devices:
+    elif tuning_config.batch_size < device_batch_size * total_devices:
         raise ValueError(
             f"Batch size ({tuning_config.batch_size}) is smaller than"
-            f" loader batch size({device_batch_size} samples per device × {n_devices} devices)"
+            f" loader batch size({device_batch_size} samples per device × {total_devices} devices)"
             " try using fewer devices"
         )
-    elif tuning_config.batch_size % (device_batch_size * n_devices):
-        remainder = tuning_config.batch_size % device_batch_size * n_devices
+    elif tuning_config.batch_size % (device_batch_size * total_devices):
+        remainder = tuning_config.batch_size % device_batch_size * total_devices
         logger.warning(
             f"Batch size ({tuning_config.batch_size}) is not a muliple"
-            f" of loader batch size({device_batch_size} samples per device × {n_devices} devices)"
+            f" of loader batch size({device_batch_size} samples per device × {total_devices} devices)"
             f" the actual tuning batch size used will be {tuning_config.batch_size-remainder}."
         )
 
     # A pl Trainer batch is in fact one batch per device, so if we use multiple devices
     accumulate_grad_batches = tuning_config.batch_size // (
-        device_batch_size * n_devices
+        device_batch_size * total_devices
     )
     logger.info(f"Using {accumulate_grad_batches} steps gradient accumulation.")
 
     # In DP mode, every batch is split between the devices
     if accelerator == "dp":
-        loader_batch_size = device_batch_size * n_devices
+        loader_batch_size = device_batch_size * total_devices
     else:
         loader_batch_size = device_batch_size
 
@@ -394,49 +393,24 @@ def main(
     additional_kwargs: Dict[str, Any] = dict()
     if profile:
         logger.info("Running in profile mode")
-        profiler = pl.profiler.AdvancedProfiler(
-            output_filename=str(out_dir / "profile.txt")
-        )
+        profiler = pl.profiler.AdvancedProfiler(dirpath=out_dir, filename="profile.txt")
         additional_kwargs.update({"profiler": profiler, "overfit_batches": 1024})
 
     if guess_batch_size:
         logger.info("Automatic batch size selection")
         additional_kwargs.update({"auto_scale_batch_size": "binsearch"})
 
-    if accelerator is not None and "ddp" in accelerator:
+    if strategy is not None and "ddp" in strategy:
         cast(List, additional_kwargs.setdefault("plugins", [])).append(
             DDPPlugin(find_unused_parameters=profile),
         )
 
-    if accelerator == "ddp_cpu":
-        # FIXME: works but seems like bad practice
-        additional_kwargs["num_processes"] = n_gpus
-        n_gpus = 0
-
-    if sharded_ddp:
-        if accelerator == "ddp":
-            logger.info("Using sharded DDP")
-            cast(List[str], additional_kwargs.setdefault("plugins", [])).append(
-                "ddp_sharded"
-            )
-        elif accelerator == "ddp_spawn":
-            logger.info("Using sharded spawn DDP")
-            cast(List[str], additional_kwargs.setdefault("plugins", [])).append(
-                "ddp_sharded_spawn"
-            )
-        else:
-            logger.warning(
-                "--sharded-ddp only makes sense when using ddp accelerators. Ignoring the flag."
-            )
-
-    if n_gpus:
+    if accelerator == "gpu":
         if use_fp16:
-            logger.info(f"Training the model on {n_gpus} GPUs with half precision")
+            logger.info(f"Training the model on {num_devices} GPUs with half precision")
             additional_kwargs["precision"] = 16
-    elif accelerator == "ddp_cpu":
-        logger.info(
-            f"Training the model on CPU in {additional_kwargs['num_processes']} processes"
-        )
+    elif accelerator == "cpu":
+        logger.info(f"Training the model on CPU in {num_devices} processes")
     else:
         logger.info("Training the model on CPU")
 
@@ -455,7 +429,7 @@ def main(
                 save_period,
             )
         )
-    if profile and n_gpus and accelerator is not None and "cpu" not in accelerator:
+    if profile and accelerator == "gpu":
         callbacks.append(pl.callbacks.GPUStatsMonitor())
 
     if checkpoint is not None:
@@ -472,16 +446,17 @@ def main(
 
     trainer = pl.Trainer(
         accumulate_grad_batches=accumulate_grad_batches,
-        auto_select_gpus=n_gpus > 0,
+        accelerator=accelerator,
+        auto_select_gpus=accelerator == "gpu",
         callbacks=callbacks,
         default_root_dir=out_dir,
-        accelerator=accelerator,
-        gpus=n_gpus,
+        devices=num_devices,
         gradient_clip_val=tuning_config.gradient_clipping,
         limit_val_batches=1.0 if val_path is not None else 0,
         max_epochs=max_epochs,
         max_steps=max_steps,
         num_nodes=n_nodes,
+        strategy=strategy,
         **additional_kwargs,
     )
 


### PR DESCRIPTION
## Changed

- The command line options have been changed to reflect change in Lightning
  - `--accelerator` is now used for devices, tested values are `"cpu"` and `"gpu"`
  - `--strategy` now specifies how to train, tested values are `None` (missing), `"ddp"`,
    `"ddp_sharded"` `"ddp_spawn"` and`"ddp_sharded_spawn"`.
  - No more option to select sharded training, use the strategy alias for that
  - `--n-gpus` has been renamed to `--num-devices`.

## Internal

- Tests now run in [Pytest](https://pytest.org) using the [console-scripts
  plugin](https://github.com/kvas-it/pytest-console-scripts) for smoke tests.
- Smoke tests now include `ddp_spawn` tests and tests on gpu devices if available.