### PR TITLE
Add support for remote datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
     hopefully come later.
 - `--val-check-period` and  `--step-save-period` allowing to evaluate and save a model decoupled
   from epochs. This should be useful for training with very long epochs.
+- The datasets path in `zeldarose-transformer` can now be 🤗 hub handles. See `--help`.
 
 ### Changed
 

--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,0 +1,32 @@
+# Licence
+
+## General licence
+
+The following licence applies to all the files in this repository unless stated otherwise
+
+Copyright 2021 Loïc Grobol <loic.grobol@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## Licence exceptions
+
+- [`tests/fixtures/raw.txt`](tests/fixtures/raw.txt) is a mashup including the following [CC-BY-SA
+  4.0](https://creativecommons.org/licenses/by-sa/4.0/) licenced texts
+
+  - [*Rayons émis par les composés de l’uranium et du
+    thorium*](https://fr.wikisource.org/wiki/Rayons_%C3%A9mis_par_les_compos%C3%A9s_de_l%E2%80%99uranium_et_du_thorium),
+    Maria Skłodowska Curie
+  - [*Les maîtres sonneurs*](https://fr.wikisource.org/wiki/Les_Ma%C3%AEtres_sonneurs), George Sand

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
 tests =
     pytest
     pytest-console-scripts
+    pytest-lazy-fixture
 
 [options.entry_points]
 console_scripts =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
 import pathlib
+from typing import Union
 
 import pytest
+
+from pytest_lazyfixture import lazy_fixture
 
 
 fixtures_dir = pathlib.Path(__file__).parent / "fixtures"
@@ -14,6 +17,11 @@ def test_data_dir() -> pathlib.Path:
 @pytest.fixture(scope="session")
 def raw_text_path(test_data_dir: pathlib.Path) -> pathlib.Path:
     return test_data_dir / "raw.txt"
+
+
+@pytest.fixture(scope="session")
+def remote_raw_text() -> str:
+    return "lgrobol/openminuscule:text:train"
 
 
 @pytest.fixture(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -134,3 +134,36 @@ def test_train_rtd(
         *extra_args,
     )
     assert ret.success
+
+
+def test_train_mlm_with_remote_dataset(
+    mlm_task_config: pathlib.Path,
+    remote_raw_text: str,
+    script_runner: pytest_console_scripts.ScriptRunner,
+    tmp_path: pathlib.Path,
+):
+    ret = script_runner.run(
+        "zeldarose-transformer",
+        "--strategy",
+        "ddp_spawn",
+        "--num-devices",
+        "2",
+        "--config",
+        str(mlm_task_config),
+        "--tokenizer",
+        "lgrobol/roberta-minuscule",
+        "--model-config",
+        "lgrobol/roberta-minuscule",
+        "--device-batch-size",
+        "8",
+        "--out-dir",
+        str(tmp_path / "train-out"),
+        "--cache-dir",
+        str(tmp_path / "tokenizer-cache"),
+        "--val-text",
+        remote_raw_text,
+        remote_raw_text,
+        "--max-epochs",
+        "2",
+    )
+    assert ret.success

--- a/zeldarose/train_transformer.py
+++ b/zeldarose/train_transformer.py
@@ -147,10 +147,7 @@ class SavePretrainedModelCallback(pl.callbacks.Callback):
 # TODO: allow reading all these from a config file (except perhaps for paths)
 # TODO: refactor the api to have a single `zeldarose` entrypoint with subcommands.
 @click.command()
-@click.argument(
-    "raw_text",
-    type=click_pathlib.Path(resolve_path=True, exists=True, dir_okay=False),
-)
+@click.argument("raw_text")
 @click.option(
     "--accelerator",
     default="cpu",
@@ -288,8 +285,11 @@ class SavePretrainedModelCallback(pl.callbacks.Callback):
 @click.option(
     "--val-text",
     "val_path",
-    type=click_pathlib.Path(resolve_path=True, exists=True, dir_okay=False),
-    help="A raw corpus for validation",
+    help=(
+        "A raw corpus for validation."
+        " Either as a path or as a `handle:config:split` identifier for 🤗 hub."
+        " (handle can be a url)"
+    ),
 )
 @click.option("--verbose", is_flag=True, help="More detailed logs")
 def main(
@@ -310,15 +310,20 @@ def main(
     out_dir: pathlib.Path,
     pretrained_model: Optional[str],
     profile: bool,
-    raw_text: pathlib.Path,
+    raw_text: str,
     step_save_period: Optional[int],
     strategy: Optional[str],
     tokenizer_name: Optional[str],
     use_fp16: bool,
     val_check_period: Optional[int],
-    val_path: Optional[pathlib.Path],
+    val_path: Optional[str],
     verbose: bool,
 ):
+    """Train a Transformer model.
+
+     The training dataset should be given with `raw_text` as either a path to a local file or or as a
+    `handle:config:split` identifier for 🤗 hub (handle can be a url).
+    """
     if (slurm_procid := os.environ.get("SLURM_PROCID")) is not None:
         log_file = out_dir / "logs" / f"train{slurm_procid}.log"
     else:


### PR DESCRIPTION
## Added

- The datasets path in `zeldarose-transformer` can now be 🤗 hub handles. See `--help`.