### PR TITLE
Fix datasets 2.4 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Changed
 
 - Bumped `torchmetrics` minimal version to 0.9
+- Bumped `datasets` minimal version to 2.4
+
+### Fixed
+
+- Dataset fingerprinting/caching issues [#31](https://github.com/LoicGrobol/zeldarose/issues/31)
 
 ## [0.5.0] — 2022-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - Bumped `torchmetrics` minimal version to 0.9
 - Bumped `datasets` minimal version to 2.4
+- Bumped `torch` max version to 1.12
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ This is somewhat tricky, you have several options
   environment, you might have to check the cache directory pointed to by the`HF_DATASETS_CACHE`
   environment variable.
 
-
 ## Inspirations
 
 - <https://github.com/shoarora/lmtuners>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ keywords = [
 requires-python = ">=3.8"
 dependencies = [
     "click >= 8.0.4, < 9.0.0",
-    "datasets",
+    "datasets >= 2.2, < 2.5",
     "filelock",
     "loguru",
     "pydantic",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pytorch-lightning >= 1.5.6, < 1.7.0",
     "rich",
     "sacremoses",
-    "torch > 1.8, < 1.12",
+    "torch > 1.8, < 1.13",
     "torchmetrics >= 0.9, < 1.0",
     "tokenizers ~= 0.10",
     "toml",

--- a/zeldarose/train_transformer.py
+++ b/zeldarose/train_transformer.py
@@ -279,7 +279,7 @@ class SavePretrainedModelCallback(pl.callbacks.Callback):
     help=(
         "A raw corpus for validation."
         " Either as a path or as a `handle:config:split` identifier for 🤗 hub."
-        " (handle can be a url)"
+        " (handle can be a url), e.g. `lgrobol/openminuscule:text:train`"
     ),
 )
 @click.option("--verbose", is_flag=True, help="More detailed logs")


### PR DESCRIPTION
Our dataset fingerprinting strategy doesn't work anymore with the new release of `datasets`. The path of least resistance is to stop using lambdas for data processing and use named internal functions instead.

This should also fix #31 