### PR TITLE
Use Trainer.fit(..., ckpt_path=checkpoint) to resume from a checkpoint.

### DIFF
--- a/zeldarose/train_transformer.py
+++ b/zeldarose/train_transformer.py
@@ -518,10 +518,6 @@ def main(
             )
         )
 
-    if checkpoint is not None:
-        logger.info(f"Restarting training from the checkpoint at {checkpoint}")
-        additional_kwargs["resume_from_checkpoint"] = checkpoint
-
     if tuning_config.lr_decay_steps is not None and tuning_config.lr_decay_steps != -1:
         max_steps = tuning_config.lr_decay_steps + tuning_config.warmup_steps
         logger.info(
@@ -550,7 +546,7 @@ def main(
 
     logger.info("Start training")
 
-    trainer.fit(training_model, datamodule=datamodule)
+    trainer.fit(training_model, datamodule=datamodule, ckpt_path=checkpoint)
 
     save_dir = out_dir / model_name
     logger.info(f"Saving the final model in {save_dir}")

--- a/zeldarose/train_transformer.py
+++ b/zeldarose/train_transformer.py
@@ -518,6 +518,9 @@ def main(
             )
         )
 
+    if checkpoint is not None:
+        logger.info(f"Restarting training from the checkpoint at {checkpoint}")
+
     if tuning_config.lr_decay_steps is not None and tuning_config.lr_decay_steps != -1:
         max_steps = tuning_config.lr_decay_steps + tuning_config.warmup_steps
         logger.info(


### PR DESCRIPTION
The `resume_from_checkpoint` parameter for the Trainer class is deprecated in pytorch-lightning 2.0.0, providing the `checkpoint` option in zeldarose `tran-transformer` command causes an error when pytorch-lightning is >= 2.0.0.
I suggest using the `ckpt_path` parameter for the `Trainer.fit` function to achieve continual pre-training.